### PR TITLE
rmdirSync -> rmSync

### DIFF
--- a/src/newman/reports/ReportGenerator.js
+++ b/src/newman/reports/ReportGenerator.js
@@ -75,7 +75,7 @@ class ReportGenerator {
   }
 
   initReportDir() {
-    fs.rmdirSync(this.reportsPath.baseDir, { recursive: true });
+    fs.rmSync(this.reportsPath.baseDir, { force: true, recursive: true });
     fs.mkdirSync(this.reportsPath.baseDir, { recursive: true });
   }
 


### PR DESCRIPTION
@sakaguchi-diverta お願いします。

https://nodejs.org/api/fs.html#fsrmdirsyncpath-options
`fs.rmdirSync()`のオプションに`recursive`を渡すのはdeprecatedだったので、`fs.rmSync()`に置き換え