### PR TITLE
Add --insecure option

### DIFF
--- a/bin/commands/run-all.js
+++ b/bin/commands/run-all.js
@@ -5,12 +5,12 @@
 const { CollectionRunner } = require('../../src/newman/runner');
 const { NewmanConfig } = require('../../src/newman/config');
 
-module.exports = () => {
+module.exports = (options = {}) => {
   const newmanConfig = NewmanConfig.load();
   const runner = new CollectionRunner(newmanConfig);
 
   // Run all collections
-  runner.runAll().then((results) => {
+  runner.runAll(options).then((results) => {
     if (results.some((result) => result.status === 'rejected')) {
       process.exit(1);
     }

--- a/bin/commands/run.js
+++ b/bin/commands/run.js
@@ -6,7 +6,7 @@ const glob = require('glob');
 const path = require('path');
 const fs = require('fs');
 
-module.exports = (collection, environment = '', globals = '') => {
+module.exports = (collection, environment = '', globals = '', options = {}) => {
   const { CollectionRunner } = require('../../src/newman/runner');
   const { NewmanConfig } = require('../../src/newman/config');
 
@@ -69,7 +69,9 @@ module.exports = (collection, environment = '', globals = '') => {
       globalsPath,
       targetSite,
       apiId,
-      testType
+      testType,
+      null,
+      options
     )
     .catch((err) => {
       process.exit(1);

--- a/bin/kuroco-newman.js
+++ b/bin/kuroco-newman.js
@@ -13,17 +13,23 @@ program
     `specify environment file`,
     ''
   )
-  .option('-g --globals <globals-file>', `specify globals file`, '')
+  .option('-g, --globals <globals-file>', `specify globals file`, '')
   .option('-c, --collection <collection>', `specify collection file`)
+  .option('-k, --insecure', `disables SSL validation`)
   .action((options) => {
+    // configure common options
+    const runOptions = {
+      ...(options.hasOwnProperty('insecure') ? { insecure: options.insecure } : {})
+    };
+
     if (options.hasOwnProperty('collection')) {
       // run specified collection
       const runCollection = require('./commands/run.js');
-      runCollection(options.collection, options.environment, options.globals);
+      runCollection(options.collection, options.environment, options.globals, runOptions);
     } else {
       // run all collections
       const runAll = require('./commands/run-all.js');
-      runAll();
+      runAll(runOptions);
     }
   });
 

--- a/src/newman/runner/CollectionRunner.js
+++ b/src/newman/runner/CollectionRunner.js
@@ -47,7 +47,8 @@ class CollectionRunner {
     targetSite,
     id,
     testType,
-    alias = null
+    alias = null,
+    options
   ) {
     const reportRootPath = this.reportGenerator.getRootPath();
     const targetName = alias || targetSite;
@@ -73,6 +74,7 @@ class CollectionRunner {
             },
           },
           workingDir: `${this.absoluteBaseDir}/${targetSite}`,
+          ...options,
         },
         (err, summary) => {
           this.reportGenerator.writeSummary(
@@ -92,11 +94,11 @@ class CollectionRunner {
     });
   }
 
-  runAll() {
+  runAll(options) {
     this.reportGenerator.initReportDir();
 
     const allRunArguments = this.newmanConfig.target.flatMap((site) =>
-      this.makeSiteCollectionsRunArguments(site)
+      this.makeSiteCollectionsRunArguments(site, options)
     );
 
     return (async () => {
@@ -115,7 +117,7 @@ class CollectionRunner {
     })();
   }
 
-  makeSiteCollectionsRunArguments(site) {
+  makeSiteCollectionsRunArguments(site, options) {
     const runArguments = [];
     site.collections.forEach((collection) => {
       Object.keys(collection.files).forEach((testType) => {
@@ -141,6 +143,7 @@ class CollectionRunner {
             id: collection.id,
             testType,
             alias: site.alias,
+            options,
           });
         });
       });


### PR DESCRIPTION
@sakaguchi-diverta 
ご確認よろしくお願いします

Runnerに `insecure` オプションを追加
ローカル環境を対象に実行する場合など、証明書の検証を無効化したい場合に利用する想定です。

Example
```
npx kuroco-newman run -k
npx kuroco-newman run --insecure
```

newman - Command Line Options
https://www.npmjs.com/package/newman#newman-run-collection-file-source-options

